### PR TITLE
Add a shareable ESLint config for use in Hypothesis projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,20 @@ Hypothesis Front-end Toolkit
 ============================
 
 This repository contains shared tools, documentation and resources for
-front-end projects in Hypothesis. 
+front-end projects in Hypothesis.
 
 ## Documentation
 
-This `docs/` folder contains our style guides and other documentation which is
+The `docs/` folder contains our style guides and other documentation which is
 useful when writing Hypothesis code across different projects.
 
 * The [CSS Style Guide](docs/css-style-guide.md)
+
+## Packages
+
+The `packages/` folder contains a set of npm packages that provide resources such
+as base config files for front-end tooling, utility scripts etc. that are
+useful across multiple Hypothesis projects. These include:
+
+ - [**eslint-config-hypothesis**](packages/eslint-config-hypothesis) - A [sharable configuration](http://eslint.org/docs/developer-guide/shareable-configs)
+   for ESLint

--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -1,0 +1,56 @@
+'use strict';
+
+module.exports = {
+  env: {
+    mocha: true,
+    commonjs: true,
+    browser: true,
+  },
+  extends: 'eslint:recommended',
+  globals: {
+    assert: false,
+    sinon: false,
+    Promise: false,
+  },
+  rules: {
+    'array-callback-return': "error",
+    'block-scoped-var': "error",
+    'comma-dangle': ["error", "always-multiline"],
+    'consistent-this': ["error", "self"],
+    'consistent-return': "error",
+    'curly': "error",
+    'dot-notation': "error",
+    'eqeqeq': "error",
+    'guard-for-in': "error",
+    'indent': ["error", 2],
+    'new-cap': "error",
+    'no-caller': "error",
+    'no-case-declarations': "error",
+    'no-console': [
+      'error',
+      { allow: ['warn', "error"] },
+    ],
+    'no-extra-bind': "error",
+    'no-lone-blocks': "error",
+    'no-lonely-if': "error",
+    'no-multiple-empty-lines': "error",
+    'no-self-compare': "error",
+    'no-throw-literal': "error",
+    'no-undef-init': "error",
+    'no-unneeded-ternary': "error",
+    'no-unused-expressions': "error",
+    'no-use-before-define': [
+      'error',
+      {functions: false},
+    ],
+    'no-useless-concat': "error",
+    'one-var-declaration-per-line': ["error", "always"],
+    'quotes': ["error", "single", {"avoidEscape": true}],
+    'semi': "error",
+    'strict': ["error", "safe"],
+  },
+  parserOptions: {
+    ecmaVersion: 6,
+  }
+};
+

--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "eslint-config-hypothesis",
+  "version": "1.0.0",
+  "description": "A base ESLint configuration for Hypothesis projects",
+  "homepage": "https://hypothes.is",
+  "bugs": "https://github.com/hypothesis/frontend-toolkit/issues",
+  "repository": "hypothesis/frontend-toolkit",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "BSD-2-Clause"
+}


### PR DESCRIPTION
With this, any other Hypothesis project will be able to use the same ESLint config as the client as a starting point by adding an `eslint-package-hypothesis` dependency, a `.eslintrc` file containing:

``` json
{
  "extends": "hypothesis"
}
```

and a task (using Make, gulp or whatever that project uses) that runs the tool.

More generally, this commit adds a place to put shared configs, utility scripts, design resources and other tools that are useful across multiple projects. Given that we want to achieve both design and tooling consistency across our projects where appropriate, I have chosen to put the package here in a `packages/` where we can document all of them together rather than in a separate Git repo.
