### PR TITLE
Only use js-* and is-* CSS classes in JavaScript

### DIFF
--- a/docs/css-style-guide.md
+++ b/docs/css-style-guide.md
@@ -74,7 +74,8 @@ The SASS for Hypothesis projects is organized into several parts:
  * Use a `u-` prefix for utility classes. eg. A class for hiding DOM elements would be called `u-hidden`
 
 ### Classes Used in Code
-* Only reference classes with `js-` and `is-` prefixes in JavaScript code, except for tests where other classes may be referenced
+
+* Only reference classes with `js-` and `is-` prefixes in JavaScript code
 * Use names with a `js-` prefix for handle or "ref" classes that are used by JS to get a reference to particular DOM elements. These classes should not appear in stylesheets
 
 ## SASS Features


### PR DESCRIPTION
Simplify the rule:

> Only reference classes with js- and is- prefixes in JavaScript code,
> except for tests where other classes may be referenced

to just:

> Only reference classes with js- and is- prefixes in JavaScript code

Simpler rules are easier to remember and to follow (if you can avoid
using words like "except" and "but" in guidelines, that's a good thing).

The exception for test code also seems to contradict the rule that
immediately follows it:

> Use names with a js- prefix for handle or "ref" classes that are used
> by JS to get a reference to particular DOM elements.

It's also just more consistent to have _all_ JavaScript code using
`js-*` classes to find elements, rather than some elements having `js-*`
classes and some (because they're only accessed by tests _and_ there
happened to be an existing non-`js-*` class that could be used) not
having them.

Otherwise you'll end up with some test code using `js-*` classes and
some test code using other CSS classes for the same purpose.

In this case:

* First some tests are written and the test JS code uses other CSS
  classes because there was no existing `js-*` class
* Later someone comes along later and adds _production_ code that needs
  to find an element and so adds a `js-*` class to the element
* The person doesn't remember to update the existing tests to use the
  new `js-*` class

Then you could end up with tests using other CSS classes to find
elements even though there's a `js-*` class on the element.

I think it'll be much harder to see, from reading the code, what the
pattern / rule being applied regarding using CSS classes from JS is. On
the other hand, if JS _always_ uses only `js-*` and `is-*` classes that
pattern should be pretty clear in the code.