### PR TITLE
Update eslint-config-hypothesis to reflect current conventions across projects

### DIFF
--- a/packages/eslint-config-hypothesis/.prettierrc
+++ b/packages/eslint-config-hypothesis/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/packages/eslint-config-hypothesis/README.md
+++ b/packages/eslint-config-hypothesis/README.md
@@ -1,0 +1,29 @@
+# eslint-config-hypothesis
+
+A [shareable ESLint configuration](https://eslint.org/docs/developer-guide/shareable-configs)
+for Hypothesis frontend projects.
+
+To use it:
+
+1. Add `eslint-config-hypothesis` as a dependency to your project
+2. Add the config's peer dependencies (see `peerDependencies` in `package.json`)
+   to your project's dependencies
+3. Add an ESLint config file to the repository which extends the "hypothesis"
+   config. For example, a `.eslintrc` file with the following content:
+
+   ```js
+   {
+     "extends": ["hypothesis"]
+   }
+   ```
+
+## Rule notes
+
+- All rules from `eslint:recommended` are enabled
+- All rules are configured to produce errors and not warnings. This is based on
+  the principle that an issue is either worth fixing or should be ignored, and
+  warnings just add noise
+- The config assumes that you are using mocha for tests and React/Preact for
+  any interactive UI
+- Code formatting rules that are obsoleted by automated formatters are disabled.
+  You should [*use Prettier*](https://prettier.io) to auto-format code.

--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -6,51 +6,66 @@ module.exports = {
     commonjs: true,
     browser: true,
   },
-  extends: 'eslint:recommended',
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
   globals: {
     assert: false,
     sinon: false,
     Promise: false,
   },
   rules: {
-    'array-callback-return': "error",
-    'block-scoped-var': "error",
-    'comma-dangle': ["error", "always-multiline"],
-    'consistent-this': ["error", "self"],
-    'consistent-return': "error",
-    'curly': "error",
-    'dot-notation': "error",
-    'eqeqeq': "error",
-    'guard-for-in': "error",
-    'indent': ["error", 2],
-    'new-cap': "error",
-    'no-caller': "error",
-    'no-case-declarations': "error",
-    'no-console': [
-      'error',
-      { allow: ['warn', "error"] },
-    ],
-    'no-extra-bind': "error",
-    'no-lone-blocks': "error",
-    'no-lonely-if': "error",
-    'no-multiple-empty-lines': "error",
-    'no-self-compare': "error",
-    'no-throw-literal': "error",
-    'no-undef-init': "error",
-    'no-unneeded-ternary': "error",
-    'no-unused-expressions': "error",
-    'no-use-before-define': [
-      'error',
-      {functions: false},
-    ],
-    'no-useless-concat': "error",
-    'one-var-declaration-per-line': ["error", "always"],
-    'quotes': ["error", "single", {"avoidEscape": true}],
-    'semi': "error",
-    'strict': ["error", "safe"],
-  },
-  parserOptions: {
-    ecmaVersion: 6,
-  }
-};
+    // eslint:recommended rules
+    'array-callback-return': 'error',
+    'block-scoped-var': 'error',
+    'comma-dangle': ['error', 'always-multiline'],
+    'consistent-this': ['error', 'self'],
+    'consistent-return': 'error',
+    curly: 'error',
+    'dot-notation': 'error',
+    eqeqeq: 'error',
+    'guard-for-in': 'error',
+    'new-cap': 'error',
+    'no-caller': 'error',
+    'no-case-declarations': 'error',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
+    'no-extra-bind': 'error',
+    'no-lone-blocks': 'error',
+    'no-lonely-if': 'error',
+    'no-multiple-empty-lines': 'error',
+    'no-self-compare': 'error',
+    'no-throw-literal': 'error',
+    'no-undef-init': 'error',
+    'no-unneeded-ternary': 'error',
+    'no-unused-expressions': 'error',
+    'no-use-before-define': ['error', { functions: false }],
+    'no-useless-concat': 'error',
+    'one-var-declaration-per-line': ['error', 'always'],
+    strict: ['error', 'safe'],
 
+    // ES2015+ style rules
+    'no-var': 'error',
+
+    // plugin:react/recommended rules
+    'react/self-closing-comp': 'error',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'error',
+
+    // mocha rules
+    'mocha/no-exclusive-tests': 'error',
+  },
+
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+
+  plugins: ['mocha', 'react', 'react-hooks'],
+
+  settings: {
+    react: {
+      pragma: 'createElement',
+      version: '16.8',
+    },
+  },
+};

--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hypothesis",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A base ESLint configuration for Hypothesis projects",
   "homepage": "https://hypothes.is",
   "bugs": "https://github.com/hypothesis/frontend-toolkit/issues",
@@ -8,6 +8,11 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "peerDependencies": {
+    "eslint-plugin-mocha": "^5.2.1",
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
 - Add React plugin configuration, since we are now using Preact or
   React as the UI library for all frontend projects
 - Add mocha configuration, as we use mocha for tests across all
   projects
 - Enable modern ES language features and JSX
 - Add a README.md with setup instructions
 - Disable code formatting lint checks that are made obsolete by
   Prettier