### PR TITLE
Disable comma dangle rule and add documentation links

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -16,7 +16,6 @@ module.exports = {
     // eslint:recommended rules
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
-    'comma-dangle': ['error', 'always-multiline'],
     'consistent-this': ['error', 'self'],
     'consistent-return': 'error',
     curly: 'error',

--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -13,7 +13,12 @@ module.exports = {
     Promise: false,
   },
   rules: {
-    // eslint:recommended rules
+    // Standard ESLint rules.
+    //
+    // See https://eslint.org/docs/rules/.
+    //
+    // Stylistic rules are omitted for things that are handled automatically
+    // by Prettier.
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
     'consistent-this': ['error', 'self'],
@@ -40,10 +45,15 @@ module.exports = {
     'one-var-declaration-per-line': ['error', 'always'],
     strict: ['error', 'safe'],
 
-    // ES2015+ style rules
+    // Stylistic rules about use of ES2015+ features.
+    //
+    // See https://eslint.org/docs/rules/#ecmascript-6
     'no-var': 'error',
 
     // plugin:react/recommended rules
+    //
+    // See https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
+    // and https://reactjs.org/docs/hooks-rules.html#eslint-plugin
     'react/self-closing-comp': 'error',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',


### PR DESCRIPTION
Context: https://hypothes-is.slack.com/archives/C1M8NH76X/p1572264109045700

This disables the comma-dangle rule which conflicts with our standard Prettier configuration as of ESLint v6.6.0. In general, ESLint rules that are made obsolete by Prettier should be disabled.

I also added relevant links to external documentation to make it easier to look up what the various rules do in future.