### PR TITLE
Detect default ES module exports

### DIFF
--- a/packages/convert-to-es-modules/test/convert-exports-test.js
+++ b/packages/convert-to-es-modules/test/convert-exports-test.js
@@ -106,5 +106,10 @@ describe("convert-exports", () => {
       const code = `module.exports = SomeClass;`;
       assert.equal(detectDefaultExport(code), true);
     });
+
+    it("returns `true` if module has a default ES export", () => {
+      const code = `export default function foo () {}`;
+      assert.equal(detectDefaultExport(code), true);
+    });
   });
 });


### PR DESCRIPTION
When converting an existing project it is easiest to do top-down where
modules are converted before their dependencies. This is because Babel's
`import` conversion supports importing from either ES _or_ CommonJS modules.

If however a module being converted depends on a module which has
already been converted, we should still detect whether to use a default
import or namespace import (`import foo from "foo"` vs `import * as foo
from "foo"`) correctly.