### PR TITLE
convert-to-es-modules: Sort and group imports according to our conventions

### DIFF
--- a/packages/convert-to-es-modules/src/sort-imports.js
+++ b/packages/convert-to-es-modules/src/sort-imports.js
@@ -1,0 +1,122 @@
+"use strict";
+
+const BLANK_LINE = /^\s*$/;
+const IMPORT_LINE = /^\s*import.*from ['"](.*)['"];?/;
+
+/**
+ * Extract the module path from an ES `import` statement.
+ */
+function getImportPath(line) {
+  const importMatch = line.match(IMPORT_LINE);
+  return importMatch ? importMatch[1] : null;
+}
+
+/**
+ * Sort and group a list of import lines.
+ *
+ * @param {string[]} - Lines that are either empty or contain import declarations.
+ */
+function sortAndGroupImports(lines) {
+  // Group imports by location relative to calling package.
+  const imports = {
+    vendor: [],
+    samePackage: [],
+    sameDir: []
+  };
+
+  const getCategory = path => {
+    if (path.startsWith("./")) {
+      return "sameDir";
+    } else if (path.startsWith("../")) {
+      return "samePackage";
+    } else {
+      return "vendor";
+    }
+  };
+
+  for (let line of lines) {
+    const importPath = getImportPath(line);
+    if (!importPath) {
+      // Skip blank lines.
+      continue;
+    }
+
+    const category = getCategory(importPath);
+    imports[category].push(line);
+  }
+
+  const sortedLines = [];
+
+  // Sort each section and add a blank line between sections.
+  Object.keys(imports).forEach((section, index, sections) => {
+    // console.log('imports in category', section, ':', imports[section]);
+    const sorted = imports[section].sort((a, b) =>
+      getImportPath(a).localeCompare(getImportPath(b))
+    );
+
+    if (sorted.length > 0) {
+      if (sortedLines.length > 0) {
+        sortedLines.push("");
+      }
+      sortedLines.push(...sorted);
+    }
+  });
+
+  return sortedLines;
+}
+
+/**
+ * Insert blank lines between local and third-party package imports.
+ *
+ * @param {string} code
+ */
+function groupImportsInFile(code) {
+  const lines = code.split("\n");
+
+  // Find groups of imports with optional blank lines before, after or in-between.
+  const lineTypes = lines
+    .map(line => {
+      if (line.match(BLANK_LINE)) {
+        return "B";
+      } else if (line.match(IMPORT_LINE)) {
+        return "I";
+      } else {
+        return "O";
+      }
+    })
+    .join("");
+
+  const importGroups = [];
+  for (let match of lineTypes.matchAll(/B*I[BI]*/g)) {
+    importGroups.push([match.index, match.index + match[0].length - 1]);
+  }
+
+  // Sort and sub-group each group of imports.
+  let output = [];
+  let prevGroupEndLine = null;
+
+  for (let [start, end] of importGroups) {
+    if (prevGroupEndLine !== null) {
+      // Add the non-import lines between the two import groups.
+      output.push("");
+      output.push(...lines.slice(prevGroupEndLine + 1, start));
+      output.push("");
+    }
+    const importLines = lines.slice(start, end + 1);
+    const sortedLines = sortAndGroupImports(importLines);
+    output.push(...sortedLines);
+    prevGroupEndLine = end;
+  }
+
+  // Add the non-import lines after the final import group.
+  if (prevGroupEndLine !== null) {
+    output.push("");
+  } else {
+    prevGroupEndLine = -1;
+  }
+  output.push(...lines.slice(prevGroupEndLine + 1));
+
+  return output.join("\n");
+}
+
+module.exports = { groupImportsInFile };

--- a/packages/convert-to-es-modules/test/convert-imports-test.js
+++ b/packages/convert-to-es-modules/test/convert-imports-test.js
@@ -25,7 +25,7 @@ describe("convert-imports", () => {
         hasDefaultExport
       );
 
-      assert.equal(output, expected);
+      assert.equal(output.trim(), expected.trim());
     });
 
     it("converts CommonJS imports to default ES imports", () => {
@@ -45,7 +45,7 @@ describe("convert-imports", () => {
         hasDefaultExport
       );
 
-      assert.equal(output, expected);
+      assert.equal(output.trim(), expected.trim());
     });
 
     it("converts named imports to ES imports", () => {
@@ -66,7 +66,47 @@ describe("convert-imports", () => {
         hasDefaultExport
       );
 
-      assert.equal(output, expected);
+      assert.equal(output.trim(), expected.trim());
+    });
+
+    [
+      // Input imports already grouped.
+      `
+        var foo = require("commander");
+        var bar = require("commander");
+
+        var local = require("./convert-imports-test");
+        var local2 = require("../src/convert-imports");
+      `,
+
+      // Input imports not grouped.
+      `
+        var foo = require("commander");
+        var bar = require("commander");
+        var local = require("./convert-imports-test");
+        var local2 = require("../src/convert-imports");
+      `
+    ].forEach(input => {
+      it("inserts a blank line between local and vendor imports", () => {
+        const expected = `
+        import * as foo from 'commander';
+        import * as bar from 'commander';
+
+        import * as local2 from '../src/convert-imports';
+
+        import * as local from './convert-imports-test';
+        `;
+
+        const hasDefaultExport = {};
+
+        const output = convertCommonJSImports(
+          input,
+          __filename,
+          hasDefaultExport
+        );
+
+        assert.equal(output.trim(), expected.trim());
+      });
     });
   });
 });

--- a/packages/convert-to-es-modules/test/sort-imports-test.js
+++ b/packages/convert-to-es-modules/test/sort-imports-test.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const { assert } = require("chai");
+
+const { groupImportsInFile } = require("../src/sort-imports");
+
+describe("sort-imports", () => {
+  describe("groupImportsInFile", () => {
+    it("sorts imports into vendor, same-package and same-dir sections", () => {
+      const input = `
+import localUtility from "../util/local-utility";
+import LocalComponent from "./LocalComponent";
+import * as vendorLib from "vendor-lib";
+import vendorFunc from "vendor-func";
+
+function MyWidget() {
+}
+      `;
+
+      const expected = `
+import vendorFunc from "vendor-func";
+import * as vendorLib from "vendor-lib";
+
+import localUtility from "../util/local-utility";
+
+import LocalComponent from "./LocalComponent";
+
+function MyWidget() {
+}
+`;
+
+      const output = groupImportsInFile(input);
+      assert.equal(output.trim(), expected.trim());
+    });
+
+    it("sorts each non-blank line delimited section independently", () => {
+      const input = `
+import zorp from "zorp";
+
+function FooBar() {}
+
+// Comment
+
+import zerg from "zerg";
+import bar from "bar";
+`;
+
+      const expected = `
+import zorp from "zorp";
+
+function FooBar() {}
+
+// Comment
+
+import bar from "bar";
+import zerg from "zerg";
+`;
+
+      const output = groupImportsInFile(input);
+      assert.equal(output.trim(), expected.trim());
+    });
+
+    [
+      // Input with leading/trailing blank lines.
+      `
+function FooBar() {}
+
+// Comment
+
+class Woot {}
+      `,
+
+      // Input with content on the first (and last) line.
+      "function FooBar() {}"
+    ].forEach(input => {
+      it("leaves input with no imports unchanged", () => {
+        const output = groupImportsInFile(input);
+        assert.equal(output.trim(), input.trim());
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR updates the logic for grouping imports after converting files to ES modules to do a more complete job of sorting and grouping imports according to a scheme which matches our de-facto conventions. Imports are grouped into three sections.

 - Vendor packages
 - Modules in other directories than the calling module
 - Modules in the same directory as the calling module

Imports within a section are sorted by import path and Import specifiers within a line are currently left as-is.

The implementation is currently based on some basic regex parsing because that's good enough. I intend to have another look at existing tools soon and see if there is something we should be re-using.