### PR TITLE
Fix import sorting losing lines before the first import in a module

### DIFF
--- a/packages/convert-to-es-modules/README.md
+++ b/packages/convert-to-es-modules/README.md
@@ -66,6 +66,31 @@ Override the tool's detection of whether a module has a default export or not:
 This option is useful if the tool's simple heuristics do not correctly detect
 whether an npm package should be treated as having a default export or not.
 
+## Limitations
+
+There are several limitations / scenarios which this script will not handle
+automatically. The recommended approach to using it is to refactor occurrences
+of these patterns before running this script, although you can also fix them up
+afterwards:
+
+- Only `var … = require` statements at the top level of a module are converted
+  to imports. This is because `import` statements must occur at the top level
+  of a file (ie. outside of any conditionals, loops or functions).
+- Detection of whether to use namespace imports (`import * as foo from "foo"`)
+  vs default imports (`import foo from "foo"`) is based on heuristics about
+  what the imported module assigns to `module.exports` (if it is a CommonJS
+  module) or whether it has an `export default` declaration (if it is an ES
+  module). The heuristic is to assume that `module.exports` assignments where
+  the right-hand side is an object literal with only identifiers as values
+  (eg. `module.exports = { foo, bar: baz }`) should be converted to namespace
+  imports. Anything else results in a default export. This heuristic may not
+  always be correct.
+- CommonJS modules which logically have both a default export (eg. a function)
+  and named exports (eg. auxilliary functions) are implemented by assigning
+  properties to the object which is the default export. When converting to ES
+  modules the idiomatic approach would be to have a default export and separate
+  named exports. This script cannot make this change automatically.
+
 ## References
 
 For information on parsing and transforming code with Babel, see the

--- a/packages/convert-to-es-modules/src/convert-imports.js
+++ b/packages/convert-to-es-modules/src/convert-imports.js
@@ -180,7 +180,17 @@ function convertCommonJSImports(code, modulePath, hasDefaultExport) {
     }
   );
 
-  const output = printAST(ast);
+  let output = printAST(ast);
+
+  // Filter out "use strict" directives as modules are always strict.
+  // We use a regex rather than AST traversal here because the parser ignores
+  // these directives when parsing the source as a module and does not include them
+  // in the AST.
+  const useStrictDirective = /^\s*['"]use strict['"][\s;]*$/g;
+  output = output
+    .split("\n")
+    .filter(line => !line.match(useStrictDirective))
+    .join("\n");
 
   // Recast does not preserve blank lines between imports after converting them
   // from `require` to `import` syntax. Since we group imports according to

--- a/packages/convert-to-es-modules/src/sort-imports.js
+++ b/packages/convert-to-es-modules/src/sort-imports.js
@@ -91,30 +91,30 @@ function groupImportsInFile(code) {
     importGroups.push([match.index, match.index + match[0].length - 1]);
   }
 
-  // Sort and sub-group each group of imports.
   let output = [];
-  let prevGroupEndLine = null;
+  let prevEnd = -1;
 
   for (let [start, end] of importGroups) {
-    if (prevGroupEndLine !== null) {
-      // Add the non-import lines between the two import groups.
-      output.push("");
-      output.push(...lines.slice(prevGroupEndLine + 1, start));
+    const linesBeforeGroup = lines.slice(prevEnd + 1, start);
+    if (linesBeforeGroup.length > 0) {
+      if (prevEnd !== -1) {
+        output.push("");
+      }
+      output.push(...linesBeforeGroup);
       output.push("");
     }
+
     const importLines = lines.slice(start, end + 1);
     const sortedLines = sortAndGroupImports(importLines);
     output.push(...sortedLines);
-    prevGroupEndLine = end;
+    prevEnd = end;
   }
 
   // Add the non-import lines after the final import group.
-  if (prevGroupEndLine !== null) {
+  if (prevEnd !== -1) {
     output.push("");
-  } else {
-    prevGroupEndLine = -1;
   }
-  output.push(...lines.slice(prevGroupEndLine + 1));
+  output.push(...lines.slice(prevEnd + 1));
 
   return output.join("\n");
 }

--- a/packages/convert-to-es-modules/test/convert-imports-test.js
+++ b/packages/convert-to-es-modules/test/convert-imports-test.js
@@ -108,5 +108,33 @@ describe("convert-imports", () => {
         assert.equal(output.trim(), expected.trim());
       });
     });
+
+    it("strips 'use strict' literals", () => {
+      const input = `
+'use strict';
+
+const foo = require("commander");
+
+function test() {
+  "use strict";
+}
+      `;
+
+      const expected = `
+import * as foo from 'commander';
+
+function test() {
+}
+`;
+
+      const hasDefaultExport = {};
+      const output = convertCommonJSImports(
+        input,
+        __filename,
+        hasDefaultExport
+      );
+
+      assert.equal(output.trim(), expected.trim());
+    });
   });
 });

--- a/packages/convert-to-es-modules/test/sort-imports-test.js
+++ b/packages/convert-to-es-modules/test/sort-imports-test.js
@@ -78,5 +78,27 @@ class Woot {}
         assert.equal(output.trim(), input.trim());
       });
     });
+
+    it("preserves lines before first import", () => {
+      const input = `
+// This is a test
+const foo = 42;
+
+import bar from "bar";
+`;
+      const output = groupImportsInFile(input);
+      assert.equal(output.trim(), input.trim());
+    });
+
+    it("preserves lines after last import", () => {
+      const input = `
+import bar from "bar";
+
+// This is a test
+const foo = 42;
+`;
+      const output = groupImportsInFile(input);
+      assert.equal(output.trim(), input.trim());
+    });
   });
 });


### PR DESCRIPTION
This PR addresses several issues found after another round of testing:

- The import sorting/grouping logic would remove lines that occurred before the first import from the final output
- Remove `"use strict"` directives from the converted modules, if they were not already removed prior to running the script
- Add some notes to the README about the limitations of the tool and a suggested approach to dealing with them by refactoring code before running the tool