### PR TITLE
Update `eslint` config to support ES6 env

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   env: {
+    es6: true,
     mocha: true,
     commonjs: true,
     browser: true,


### PR DESCRIPTION
This will allow ES6 global variables, e.g. `Set`

This change is step 1 of several. Tested locally with `client` repository using `yalc`. 

Next steps, as I understand, include publishing the npm package and removing the redundant lint rules from `client`, any other repos needed.