### PR TITLE
Update `scripts.test` field in `package.json` to avoid errors

### DIFF
--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -7,7 +7,7 @@
   "repository": "hypothesis/frontend-toolkit",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Warning: no test specified\" && exit 0"
   },
   "peerDependencies": {
     "eslint-plugin-mocha": "^5.2.1",


### PR DESCRIPTION
`eslint-config-hypothesis`’ `package.json` file has the default value
for the `scripts.test` field, which exited 1; update to log a warning
but exit 0 so that it doesn’t break builds/publishing.