### PR TITLE
Update eslint react plugin peer dependency

### DIFF
--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hypothesis",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A base ESLint configuration for Hypothesis projects",
   "homepage": "https://hypothes.is",
   "bugs": "https://github.com/hypothesis/frontend-toolkit/issues",

--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -12,7 +12,7 @@
   "peerDependencies": {
     "eslint-plugin-mocha": "^5.2.1",
     "eslint-plugin-react": "^7.12.4",
-    "eslint-plugin-react-hooks": "^1.6.0"
+    "eslint-plugin-react-hooks": "^3.0.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The woefully out-of-date peer dependency version of `eslint-plugin-react-hooks` in the `eslint-config-hypothesis` package was causing complaints with a conflict in the `client` repository.

In addition, forgive me, this PR has an extra commit that gets the `package.json` to the actual published version, which is `2.1.0`.