### PR TITLE
Version bump for `eslint-config-hypothesis`: v2.2.0 published

### DIFF
--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hypothesis",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A base ESLint configuration for Hypothesis projects",
   "homepage": "https://hypothes.is",
   "bugs": "https://github.com/hypothesis/frontend-toolkit/issues",


### PR DESCRIPTION
v2.2.0 of `eslint-config-hypothesis` has been published to `npm`.

I _thought_ that creating a new branch for the bump and then publishing would be smartypants, but, nope, it created yet another chicken-and-egg problem as tags failed to push because my local branch didn't exist yet upstream 🤦‍♀ 

Status as of present: `npm` package is successfully published @ 2.2.0 but there isn't a corresponding git tag (that tag should include the changes on this branch, if we do end up manually creating it).

I'm not clear on what series of steps would actually work as expected here!