### PR TITLE
eslint-config-hypothesis - Modernize global variables configuration

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -9,9 +9,8 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:react/recommended'],
   globals: {
-    assert: false,
-    sinon: false,
-    Promise: false,
+    assert: 'readonly',
+    sinon: 'readonly',
   },
   rules: {
     // Standard ESLint rules.


### PR DESCRIPTION
This is a tiny no-op PR to test our package publication workflow.

 - Use "readonly" instead of the historical value `false`
 - Remove obsolete `Promise` config. This is now implied by the "env"
   config