### PR TITLE
Bump ES version to 2020

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -2,7 +2,10 @@
 
 module.exports = {
   env: {
-    es6: true,
+    // Specify global variables and ES language version.
+    //
+    // See https://eslint.org/docs/user-guide/configuring#specifying-environments
+    es2020: true,
     mocha: true,
     commonjs: true,
     browser: true,
@@ -63,7 +66,6 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 2018,
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
This enables use of post-ES 2015 language features and ES language
globals. Note that some useful ES 2020 language features are not yet supported by ESLint:

 - Optional chaining
 - Nullish coalescing

This is being worked on upstream. See https://github.com/eslint/eslint/issues for details.