### PR TITLE
Widen ESLint plugin `peerDependencies` version ranges

### DIFF
--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hypothesis",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A base ESLint configuration for Hypothesis projects",
   "homepage": "https://hypothes.is",
   "bugs": "https://github.com/hypothesis/frontend-toolkit/issues",
@@ -10,9 +10,9 @@
     "test": "echo \"Warning: no test specified\" && exit 0"
   },
   "peerDependencies": {
-    "eslint-plugin-mocha": "^5.2.1",
-    "eslint-plugin-react": "^7.12.4",
-    "eslint-plugin-react-hooks": "^3.0.0"
+    "eslint-plugin-mocha": ">=5.2.1",
+    "eslint-plugin-react": ">=7.12.4",
+    "eslint-plugin-react-hooks": ">=3.0.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Widen the allowed version ranges of ESLint plugins to reduce the risk of
running into situations where plugin upgrades are held back in projects
due to them conflicting with the range specs here.

Slack thread: https://hypothes-is.slack.com/archives/C1M8NH76X/p1593088449017100