### PR TITLE
Add latest ecmaversion for eslint

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -5,7 +5,7 @@ module.exports = {
     // Specify global variables and ES language version.
     //
     // See https://eslint.org/docs/user-guide/configuring#specifying-environments
-    es2020: true,
+    es2021: true,
     mocha: true,
     commonjs: true,
     browser: true,


### PR DESCRIPTION
I want support for the new feature in ECMAScript 2021, logical
assignments:
https://dev.to/faithfulojebiyi/new-features-in-ecmascript-2021-with-code-examples-302h#logical-assignment-operator

Is there any risk babel and eslint get out of sync?