### PR TITLE
Add documentation on how to push package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,24 @@ useful across multiple Hypothesis projects. These include:
 
  - [**eslint-config-hypothesis**](packages/eslint-config-hypothesis) - A [shareable configuration](http://eslint.org/docs/developer-guide/shareable-configs)
    for ESLint
+
+### Publishing package updates
+
+Prerequisites:
+
+- Set up an npm account with 2FA enabled, and ask a lead developer to add you to
+  the [Hypothesis](https://www.npmjs.com/settings/hypothesis/packages)
+  organization in npm
+- Ensure that the package you want to publish is associated with the `developers`
+  team in this organization
+
+To publish a new version of a package:
+
+1. Ensure any changes you want to include have been merged. Then check out the
+   `master` branch of the repository and switch to the package's directory.
+2. Add an entry for the new version of the package in the changelog.
+   See https://keepachangelog.com/en/1.0.0/ for details of the format that we use.
+3. Run `npm version` with appropriate flags (eg. `npm version minor`) to update
+   the package version.
+4. Commit and push the changes from the previous step
+5. Run `npm publish` to publish the new version


### PR DESCRIPTION
Add documentation for the current workflow needed to publish packages in this repository.

Writing this has made me think that it might be worth refocusing this repository so that it contains only frontend documentation and links to useful packages. The actual packages themselves can go in separate repositories. This will allow for the use of tools which assume a 1:1 relation between packages and repositories, as well as allowing package versions to correspond to git tags.