### PR TITLE
Assume use of JSX runtime in Preact projects

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -10,7 +10,11 @@ module.exports = {
     commonjs: true,
     browser: true,
   },
-  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react/jsx-runtime',
+  ],
   globals: {
     assert: 'readonly',
     sinon: 'readonly',
@@ -75,8 +79,7 @@ module.exports = {
 
   settings: {
     react: {
-      pragma: 'createElement',
-      version: '16.8',
+      version: '18.0',
     },
   },
 };


### PR DESCRIPTION
Update ESLint config to assume that projects will use the new JSX runtime from
preact/jsx-runtime rather than the old method of transforming JSX to
`createElement`/`h` calls.

This will allow the `react/jsx-uses-react` and `react/react-in-jsx-scope`
overrides to be removed in the ESLint configs of downstream projects. See
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md#when-not-to-use-it