### PR TITLE
Migrate eslint-config-hypothesis to ESLint flat config

### DIFF
--- a/packages/eslint-config-hypothesis/index.js
+++ b/packages/eslint-config-hypothesis/index.js
@@ -1,85 +1,89 @@
-'use strict';
+import eslint from '@eslint/js';
+import mocha from 'eslint-plugin-mocha';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import globals from 'globals';
 
-module.exports = {
-  env: {
-    // Specify global variables and ES language version.
-    //
-    // See https://eslint.org/docs/user-guide/configuring#specifying-environments
-    es2021: true,
-    mocha: true,
-    commonjs: true,
-    browser: true,
-  },
-  extends: [
-    'eslint:recommended',
-    'plugin:react/recommended',
-    'plugin:react/jsx-runtime',
-  ],
-  globals: {
-    assert: 'readonly',
-    sinon: 'readonly',
-  },
-  rules: {
-    // Standard ESLint rules.
-    //
-    // See https://eslint.org/docs/rules/.
-    //
-    // Stylistic rules are omitted for things that are handled automatically
-    // by Prettier.
-    'array-callback-return': 'error',
-    'block-scoped-var': 'error',
-    'consistent-this': ['error', 'self'],
-    'consistent-return': 'error',
-    curly: 'error',
-    'dot-notation': 'error',
-    eqeqeq: 'error',
-    'guard-for-in': 'error',
-    'new-cap': 'error',
-    'no-caller': 'error',
-    'no-case-declarations': 'error',
-    'no-console': ['error', { allow: ['warn', 'error'] }],
-    'no-extra-bind': 'error',
-    'no-lone-blocks': 'error',
-    'no-lonely-if': 'error',
-    'no-multiple-empty-lines': 'error',
-    'no-self-compare': 'error',
-    'no-throw-literal': 'error',
-    'no-undef-init': 'error',
-    'no-unneeded-ternary': 'error',
-    'no-unused-expressions': 'error',
-    'no-use-before-define': ['error', { functions: false }],
-    'no-useless-concat': 'error',
-    'one-var-declaration-per-line': ['error', 'always'],
-    strict: ['error', 'safe'],
-
-    // Stylistic rules about use of ES2015+ features.
-    //
-    // See https://eslint.org/docs/rules/#ecmascript-6
-    'no-var': 'error',
-
-    // plugin:react/recommended rules
-    //
-    // See https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
-    // and https://reactjs.org/docs/hooks-rules.html#eslint-plugin
-    'react/self-closing-comp': 'error',
-    'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'error',
-
-    // mocha rules
-    'mocha/no-exclusive-tests': 'error',
-  },
-
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
+export default [
+  eslint.configs.recommended,
+  mocha.configs.flat.recommended,
+  react.configs.flat.recommended,
+  react.configs.flat['jsx-runtime'],
+  {
+    plugins: {
+      'react-hooks': reactHooks,
     },
-  },
+    rules: {
+      // Standard ESLint rules.
+      //
+      // See https://eslint.org/docs/rules/.
+      //
+      // Stylistic rules are omitted for things that are handled automatically
+      // by Prettier.
+      'array-callback-return': 'error',
+      'block-scoped-var': 'error',
+      'consistent-this': ['error', 'self'],
+      'consistent-return': 'error',
+      curly: 'error',
+      'dot-notation': 'error',
+      eqeqeq: 'error',
+      'guard-for-in': 'error',
+      'new-cap': 'error',
+      'no-caller': 'error',
+      'no-case-declarations': 'error',
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+      'no-extra-bind': 'error',
+      'no-lone-blocks': 'error',
+      'no-lonely-if': 'error',
+      'no-self-compare': 'error',
+      'no-throw-literal': 'error',
+      'no-undef-init': 'error',
+      'no-unneeded-ternary': 'error',
+      'no-unused-expressions': 'error',
+      'no-use-before-define': ['error', { functions: false }],
+      'no-useless-concat': 'error',
+      'one-var-declaration-per-line': ['error', 'always'],
+      strict: ['error', 'safe'],
 
-  plugins: ['mocha', 'react', 'react-hooks'],
+      // Stylistic rules about use of ES2015+ features.
+      //
+      // See https://eslint.org/docs/rules/#ecmascript-6
+      'no-var': 'error',
 
-  settings: {
-    react: {
-      version: '18.0',
+      // plugin:react/recommended rules
+      //
+      // See https://github.com/yannickcr/eslint-plugin-react#list-of-supported-rules
+      // and https://reactjs.org/docs/hooks-rules.html#eslint-plugin
+      'react/self-closing-comp': 'error',
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
+
+      // mocha rules
+      'mocha/no-exclusive-tests': 'error',
+      'mocha/no-mocha-arrows': 'off',
+      'mocha/no-setup-in-describe': 'off',
+      'mocha/max-top-level-suites': 'off',
+      'mocha/consistent-spacing-between-blocks': 'off',
+      'mocha/no-top-level-hooks': 'off',
+      'mocha/no-sibling-hooks': 'off',
+      'mocha/no-identical-title': 'off',
     },
-  },
-};
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        ...globals.browser,
+        sinon: 'readonly',
+        assert: 'readonly',
+      }
+    },
+    settings: {
+      react: {
+        version: '18.0'
+      }
+    },
+  }
+];

--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eslint-config-hypothesis",
   "version": "2.6.0",
+  "type": "module",
   "description": "A base ESLint configuration for Hypothesis projects",
   "homepage": "https://hypothes.is",
   "bugs": "https://github.com/hypothesis/frontend-toolkit/issues",
@@ -9,10 +10,16 @@
   "scripts": {
     "test": "echo \"Warning: no test specified\" && exit 0"
   },
+  "devDependencies": {
+    "eslint": "^9.12.0",
+    "eslint-plugin-mocha": "^10.4.3",
+    "eslint-plugin-react": "^7.34.3",
+    "eslint-plugin-react-hooks": "^5.0.0"
+  },
   "peerDependencies": {
-    "eslint-plugin-mocha": ">=5.2.1",
-    "eslint-plugin-react": ">=7.12.4",
-    "eslint-plugin-react-hooks": ">=3.0.0"
+    "eslint-plugin-mocha": ">=10.4.0",
+    "eslint-plugin-react": ">=7.34.0",
+    "eslint-plugin-react-hooks": ">=5.0.0"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Migrate eslint config to use flat format, and additionally, require ESLint 9.

The flat config format does not allow plugins to extend from other plugins, so in order to implicitly include the same plugins we were including before, the config is exported as an array, and intended to be used as follows:

```js
// eslint.config.js

import hypothesis from 'eslint-config-hypothesis';

export default [
  ...hypothesis,
  {
    // Other project config
  }
];
```

Or when using `typescript-eslint`:

```js
// eslint.config.js

import hypothesis from 'eslint-config-hypothesis';
import tseslint from 'typescript-eslint';

export default tseslint.config(
  ...hypothesis,
  ...tseslint.configs.recommended,
  {
    // Other project config
  }
);
```

Exporting config as an array is a common approach in some other eslint config packages (see `typescript-eslint`, for example), and also how ESLint documents the use of [shareable configs](https://eslint.org/docs/latest/extend/shareable-configs).

> [!NOTE]  
> This PR is easier to review [side by side](https://github.com/hypothesis/frontend-toolkit/pull/50/files?diff=split)