### PR TITLE
Disable react/no-unknown-property rule in favor of TypeScript

### DIFF
--- a/packages/eslint-config-hypothesis/react.js
+++ b/packages/eslint-config-hypothesis/react.js
@@ -17,7 +17,8 @@ export default [
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
 
-      // Prop validation should be performed by TypeScript/JSDoc.
+      // Prop type checking is handled by TypeScript.
+      'react/no-unknown-property': 'off',
       'react/prop-types': 'off',
     },
     languageOptions: {


### PR DESCRIPTION
This PR disables the `react/no-unknown-property` rule by default, as it can produce false-positives when used with preact (for example, react type definition does not include `Capture` event handler variants, like `onMouseEnterCapture`, while that's perfectly valid in preact), and we already type-check our properties via TypeScript, so this rule does not really add any extra benefit.