### PR TITLE
Replace mocha eslint plugin with vitest one

### DIFF
--- a/packages/eslint-config-hypothesis/base.js
+++ b/packages/eslint-config-hypothesis/base.js
@@ -1,10 +1,10 @@
 import eslint from '@eslint/js';
-import mocha from 'eslint-plugin-mocha';
+import vitest from '@vitest/eslint-plugin';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 
-export default [
+export default defineConfig(
   eslint.configs.recommended,
-  mocha.configs.flat.recommended,
   {
     rules: {
       // Standard ESLint rules.
@@ -43,16 +43,6 @@ export default [
       //
       // See https://eslint.org/docs/rules/#ecmascript-6
       'no-var': 'error',
-
-      // mocha rules
-      'mocha/no-exclusive-tests': 'error',
-      'mocha/no-mocha-arrows': 'off',
-      'mocha/no-setup-in-describe': 'off',
-      'mocha/max-top-level-suites': 'off',
-      'mocha/consistent-spacing-between-blocks': 'off',
-      'mocha/no-top-level-hooks': 'off',
-      'mocha/no-sibling-hooks': 'off',
-      'mocha/no-identical-title': 'off',
     },
     languageOptions: {
       globals: {
@@ -61,5 +51,15 @@ export default [
         assert: 'readonly',
       }
     },
+  },
+
+  // Tests
+  {
+    files: ['**/*-test.js'],
+    languageOptions: {
+      globals: {
+        ...vitest.environments.env.globals,
+      },
+    }
   }
-];
+);

--- a/packages/eslint-config-hypothesis/package.json
+++ b/packages/eslint-config-hypothesis/package.json
@@ -25,17 +25,17 @@
     }
   },
   "devDependencies": {
+    "@vitest/eslint-plugin": "^1.1.43",
     "eslint": "^9.12.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
-    "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^5.0.0",
     "globals": "^15.11.0",
     "typescript-eslint": "^8.10.0"
   },
   "peerDependencies": {
+    "@vitest/eslint-plugin": ">=1.1.43",
     "eslint-plugin-jsx-a11y": ">=6.10.0",
-    "eslint-plugin-mocha": ">=10.4.0",
     "eslint-plugin-react": ">=7.34.0",
     "eslint-plugin-react-hooks": ">=5.0.0",
     "globals": ">=15.11.0",


### PR DESCRIPTION
This PR aims to replace the requirement on mocha's eslint plugin with vitest one, now that most projects have been migrated to vitest.

The main issue is that the most important rule we were using from mocha's plugin was the one disallowing the use of exclusive tests (AKA `it.only(...)`), but vitest doesn0t provide an equivalent one.

However, vitest automatically detects the use of exclusive tests in CI and marks the tests as failed. Maybe this is an acceptable replacement, but it has the disadvantage that IDEs do not warn about this and you will notice only after pushing the changes.

> This PR should not be merged before all projects have been migrated to vitest