### PR TITLE
Improve eslint config for tests

### DIFF
--- a/packages/eslint-config-hypothesis/base.js
+++ b/packages/eslint-config-hypothesis/base.js
@@ -55,10 +55,17 @@ export default defineConfig(
 
   // Tests
   {
-    files: ['**/*-test.js'],
+    files: ['**/*-test.js', '**/test/*.js'],
     languageOptions: {
       globals: {
         ...vitest.environments.env.globals,
+
+        // We use `context` instead of `define` in many cases, as it was
+        // available with Mocha, before Vitest was adopted and replaced it.
+        // However, every project is responsible for aliasing `define` to
+        // `context` itself, by doing something in the lines of
+        // `globalThis.context ??= globalThis.describe`
+        context: true,
       },
     }
   }


### PR DESCRIPTION
This PR fixes eslint reporting the missing `context` global, now that the mocha plugin has been removed.

Since we still use it in downstream projects, we have decided to simply define it as a global available in tests, but documented the fact that projects still need to define the alias themeselves.

Additionally, this PR ensures the tests config applies not only to test files, but any js file under a `test` folder, which includes test utilities.